### PR TITLE
Keeping DB Keys private to comply DB request and handle path without any reproduction 

### DIFF
--- a/AppBox.xcodeproj/project.pbxproj
+++ b/AppBox.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		E1902B631E16633A00C3E0F6 /* KeychainHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeychainHandler.m; sourceTree = "<group>"; };
 		E191F7C21E1E7B2A00D2A590 /* ALAppStoreUpload.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ALAppStoreUpload.sh; sourceTree = "<group>"; };
 		E191F7C31E1E7B3B00D2A590 /* XcodeAppStoreUpload.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = XcodeAppStoreUpload.sh; sourceTree = "<group>"; };
+		E1AF8FD71E266CC000A57633 /* DropboxKeys.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DropboxKeys.h; sourceTree = "<group>"; };
 		E1CFC65C1D7E7FEA005872BE /* Common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Common.h; sourceTree = "<group>"; };
 		E1CFC65D1D7E7FEA005872BE /* Common.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Common.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -457,6 +458,7 @@
 				E1902B4C1E16617B00C3E0F6 /* NetworkHandler */,
 				E1902B4F1E16617B00C3E0F6 /* UpdateHandler */,
 				E1902B611E1662E300C3E0F6 /* KeychainHandler */,
+				E1AF8FD71E266CC000A57633 /* DropboxKeys.h */,
 				E16018F11DEC0EB700E3A377 /* Constants.h */,
 				E1CFC65C1D7E7FEA005872BE /* Common.h */,
 				E1CFC65D1D7E7FEA005872BE /* Common.m */,

--- a/AppBox/AppBoxPrefixHeader.pch
+++ b/AppBox/AppBoxPrefixHeader.pch
@@ -25,6 +25,7 @@
 #import "AppDelegate.h"
 
 #import "Constants.h"
+#import "DropboxKeys.h"
 
 #import "Common.h"
 #import "MacHandler.h"

--- a/AppBox/Common/Constants.h
+++ b/AppBox/Common/Constants.h
@@ -16,9 +16,6 @@
 #define abGitHubLatestRelease @"https://api.github.com/repos/vineetchoudhary/AppBox-iOSAppsWirelessInstallation/releases/latest"
 
 //Serives Key
-#define abDbRoot kDBRootAppFolder
-#define abDbAppkey @"" // Dropbox app key
-#define abDbScreatkey @"" //Dropbox secret key
 #define abGoogleTiny @"AIzaSyD5c0jmblitp5KMZy2crCbueTU-yB1jMqI"
 
 //notification

--- a/AppBox/Common/DropboxKeys.h
+++ b/AppBox/Common/DropboxKeys.h
@@ -1,0 +1,16 @@
+//
+//  DropboxKeys.h
+//  AppBox
+//
+//  Created by Vineet Choudhary on 11/01/17.
+//  Copyright © 2017 Developer Insider. All rights reserved.
+//
+
+#ifndef DropboxKeys_h
+#define DropboxKeys_h
+
+#define abDbRoot kDBRootAppFolder
+#define abDbAppkey @"" //enter your dropbox app key here
+#define abDbScreatkey @"" //enter your dropbox screat key here
+
+#endif /* DropboxKeys_h */

--- a/AppBox/Model/ProjectModel/XCProject.m
+++ b/AppBox/Model/ProjectModel/XCProject.m
@@ -46,14 +46,20 @@
     NSMutableDictionary *manifestDict = [[NSMutableDictionary alloc] init];
     [manifestDict setValue:[NSArray arrayWithObjects:mainItemDict, nil] forKey:@"items"];
     
-    NSString *manifestPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"manifest.plist"];
-    [manifestDict writeToFile:manifestPath atomically:YES];
-    
     [[AppDelegate appDelegate] addSessionLog:[NSString stringWithFormat:@"\n\n======\nManifest\n======\n\n %@",manifestDict]];
     
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        completion(manifestPath);
-    });
+    NSString *manifestPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"manifest.plist"];
+    if ([manifestDict writeToFile:manifestPath atomically:YES]){
+        [[AppDelegate appDelegate] addSessionLog:[NSString stringWithFormat:@"Menifest File Created and Saved at %@", manifestPath]];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion(manifestPath);
+        });
+    }else{
+        completion(nil);
+        [[AppDelegate appDelegate] addSessionLog:@"Can't able to save menifest file"];
+    }
+    
+    
 }
 
 - (void)createExportOpetionPlist{

--- a/AppBox/ViewController/HomeViewController/HomeViewController.m
+++ b/AppBox/ViewController/HomeViewController/HomeViewController.m
@@ -557,8 +557,12 @@ static NSString *const FILE_NAME_UNIQUE_JSON = @"appinfo.json";
         NSString *shareableLink = [link stringByReplacingCharactersInRange:NSMakeRange(link.length-1, 1) withString:@"1"];
         project.ipaFileDBShareableURL = [NSURL URLWithString:shareableLink];
         [project createManifestWithIPAURL:project.ipaFileDBShareableURL completion:^(NSString *manifestPath) {
-            fileType = FileTypeManifest;
-            [restClientLocal uploadFile:@"manifest.plist" toPath:project.dbDirectory.absoluteString withParentRev:nil fromPath:manifestPath];
+            if (manifestPath == nil){
+                
+            }else{
+                fileType = FileTypeManifest;
+                [restClientLocal uploadFile:@"manifest.plist" toPath:project.dbDirectory.absoluteString withParentRev:nil fromPath:manifestPath];
+            }
         }];
 
     }else if (fileType == FileTypeManifest){


### PR DESCRIPTION
### [Crashlytics Issue Link](https://fabric.io/appbox/mac/apps/com.developerinsider.appbox/issues/587602a30aeb16625bfc24a3)

### Crashlytics Log
```
Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x7fff936424da __exceptionPreprocess
1  libobjc.A.dylib                0x7fff9c55973c objc_exception_throw
2  CoreFoundation                 0x7fff9353c414 -[__NSDictionaryM setObject:forKey:]
3  DropboxOSX                     0x10ae1aaf1 (Missing)
4  AppBox                         0x10acfbc07 __60-[HomeViewController restClient:loadedSharableLink:forFile:]_block_invoke (HomeViewController.m:561)
5  libdispatch.dylib              0x7fff9aaf993d _dispatch_call_block_and_release
6  libdispatch.dylib              0x7fff9aaee40b _dispatch_client_callout
7  libdispatch.dylib              0x7fff9ab011f9 _dispatch_after_timer_callback
8  libdispatch.dylib              0x7fff9aaee40b _dispatch_client_callout
9  libdispatch.dylib              0x7fff9aafe675 _dispatch_source_latch_and_call
10 libdispatch.dylib              0x7fff9aaf2a83 _dispatch_source_invoke
11 libdispatch.dylib              0x7fff9ab0172d _dispatch_main_queue_callback_4CF
12 CoreFoundation                 0x7fff935f79e9 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
13 CoreFoundation                 0x7fff935b68dd __CFRunLoopRun
14 CoreFoundation                 0x7fff935b5ed8 CFRunLoopRunSpecific
15 HIToolbox                      0x7fff908ea935 RunCurrentEventLoopInMode
16 HIToolbox                      0x7fff908ea76f ReceiveNextEventCommon
17 HIToolbox                      0x7fff908ea5af _BlockUntilNextEventMatchingListInModeWithFilter
18 AppKit                         0x7fff9f10cdf6 _DPSNextEvent
19 AppKit                         0x7fff9f10c226 -[NSApplication _nextEventMatchingEventMask:untilDate:inMode:dequeue:]
20 AppKit                         0x7fff9f100d80 -[NSApplication run]
21 AppKit                         0x7fff9f0ca368 NSApplicationMain
22 libdyld.dylib                  0x7fff971b45ad start
```

**System Log**

```
Process:               AppBox [4867]
Path:                  /Applications/AppBox.app/Contents/MacOS/AppBox
Identifier:            com.developerinsider.AppBox
Version:               0.9.9 (1)
Code Type:             X86-64 (Native)
Parent Process:        ??? [1]
Responsible:           AppBox [4867]

Date/Time:             2017-01-11 15:41:58.438 +0530
OS Version:            Mac OS X 10.11.6 (15G31)
Report Version:        11

Time Awake Since Boot: 18000 seconds
Time Since Wake:       5200 seconds

System Integrity Protection: enabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_INSTRUCTION (SIGILL)
Exception Codes:       0x0000000000000001, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Application Specific Information:
Crashing on exception: *** setObjectForKey: key cannot be nil

Application Specific Backtrace 1:
0   CoreFoundation                      0x00007fff936424f2 __exceptionPreprocess + 178
1   libobjc.A.dylib                     0x00007fff9c55973c objc_exception_throw + 48
2   CoreFoundation                      0x00007fff9353c414 -[__NSDictionaryM setObject:forKey:] + 1236
3   DropboxOSX                          0x0000000101497af1 -[DBRestClient uploadFile:toPath:fromPath:params:] + 833
4   AppBox                              0x000000010137bc07 AppBox + 52231
5   libdispatch.dylib                   0x00007fff9aaf993d _dispatch_call_block_and_release + 12
6   libdispatch.dylib                   0x00007fff9aaee40b _dispatch_client_callout + 8
7   libdispatch.dylib                   0x00007fff9ab011f9 _dispatch_after_timer_callback + 77
8   libdispatch.dylib                   0x00007fff9aaee40b _dispatch_client_callout + 8
9   libdispatch.dylib                   0x00007fff9aafe675 _dispatch_source_latch_and_call + 2235
10  libdispatch.dylib                   0x00007fff9aaf2a83 _dispatch_source_invoke + 983
11  libdispatch.dylib                   0x00007fff9ab0172d _dispatch_main_queue_callback_4CF + 422
12  CoreFoundation                      0x00007fff935f79e9 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9
13  CoreFoundation                      0x00007fff935b68dd __CFRunLoopRun + 1949
14  CoreFoundation                      0x00007fff935b5ed8 CFRunLoopRunSpecific + 296
15  HIToolbox                           0x00007fff908ea935 RunCurrentEventLoopInMode + 235
16  HIToolbox                           0x00007fff908ea76f ReceiveNextEventCommon + 432
17  HIToolbox                           0x00007fff908ea5af _BlockUntilNextEventMatchingListInModeWithFilter + 71
18  AppKit                              0x00007fff9f10cdf6 _DPSNextEvent + 1067
19  AppKit                              0x00007fff9f10c226 -[NSApplication _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 454
20  AppKit                              0x00007fff9f100d80 -[NSApplication run] + 682
21  AppKit                              0x00007fff9f0ca368 NSApplicationMain + 1176
22  libdyld.dylib                       0x00007fff971b45ad start + 1
```