### PR TITLE
Fix Build UUID Path by escaping characters

### DIFF
--- a/AppBox/Model/ProjectModel/XCProject.m
+++ b/AppBox/Model/ProjectModel/XCProject.m
@@ -94,7 +94,8 @@
         
         //Build UUID Path
         NSString *buildUUIDPath = [_buildDirectory.resourceSpecifier stringByAppendingPathComponent:[NSString stringWithFormat:@"%@-%@",self.name, currentTime]];
-        _buildUUIDDirectory = [NSURL URLWithString:buildUUIDPath];
+         NSString* escapedBuildUUIDPath = [buildUUIDPath stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLFragmentAllowedCharacterSet]];
+        _buildUUIDDirectory = [NSURL URLWithString:escapedBuildUUIDPath];
         [[NSFileManager defaultManager] createDirectoryAtPath:buildUUIDPath withIntermediateDirectories:NO attributes:nil error:nil];
         
         //Archive Path


### PR DESCRIPTION
`buildUUIDDirectoryPath` is not escaped, sometimes `currentTime` can have spaces or `self.name`(Project name) can have non-ascii characters, these need to be escaped or the user is presented with "Unable to create file in this directory." error.

