### PR TITLE
Add DOWNLOAD_URL to 3rd Party -> Link Prefix Message

### DIFF
--- a/AppBox/Common/MailHandler/MailHandler.m
+++ b/AppBox/Common/MailHandler/MailHandler.m
@@ -33,11 +33,18 @@
     messageCopy = [messageCopy stringByReplacingOccurrencesOfString:@"{PROJECT_NAME}" withString:project.name];
     messageCopy = [messageCopy stringByReplacingOccurrencesOfString:@"{BUILD_NUMBER}" withString:project.build];
     messageCopy = [messageCopy stringByReplacingOccurrencesOfString:@"{BUILD_VERSION}" withString:project.version];
+    messageCopy = [messageCopy stringByReplacingOccurrencesOfString:@"{DOWNLOAD_URL}" withString: project.appShortShareableURL.absoluteString];
     if (project.selectedSchemes) {
         messageCopy = [messageCopy stringByReplacingOccurrencesOfString:@"{PROJECT_SCHEME}" withString:project.selectedSchemes];
     } else {
         messageCopy = [messageCopy stringByReplacingOccurrencesOfString:@"{PROJECT_SCHEME}" withString:@"Default"];
     }
+    
+    // If DOWNLOAD_URL keyword was not used, append it for compatibility
+    if (![[UserData userSlackMessage] containsString: @"{DOWNLOAD_URL}"]) {
+        messageCopy = [messageCopy stringByAppendingFormat:@" - %@", project.appShortShareableURL];
+    }
+    
     return messageCopy;
 }
 

--- a/AppBox/Common/ServiceIntegrations/HangoutClient/HangoutClient.m
+++ b/AppBox/Common/ServiceIntegrations/HangoutClient/HangoutClient.m
@@ -19,7 +19,6 @@
         NSString *hangoutMessage;
         if ([UserData userSlackMessage].length > 0) {
             hangoutMessage = [MailHandler parseMessage:[UserData userSlackMessage] forProject:project];
-            hangoutMessage = [hangoutMessage stringByAppendingFormat:@" - %@", project.appShortShareableURL];
         } else {
             hangoutMessage = [NSString stringWithFormat:@"%@ - %@ (%@) link - %@", project.name, project.version, project.build, project.appShortShareableURL];
         }

--- a/AppBox/Common/ServiceIntegrations/MSTeamsClient/MSTeamsClient.m
+++ b/AppBox/Common/ServiceIntegrations/MSTeamsClient/MSTeamsClient.m
@@ -19,7 +19,6 @@
         NSString *hangoutMessage;
         if ([UserData userSlackMessage].length > 0) {
             hangoutMessage = [MailHandler parseMessage:[UserData userSlackMessage] forProject:project];
-            hangoutMessage = [hangoutMessage stringByAppendingFormat:@" - %@", project.appShortShareableURL];
         } else {
             hangoutMessage = [NSString stringWithFormat:@"%@ - %@ (%@) link - %@", project.name, project.version, project.build, project.appShortShareableURL];
         }

--- a/AppBox/Common/ServiceIntegrations/SlackClient/SlackClient.m
+++ b/AppBox/Common/ServiceIntegrations/SlackClient/SlackClient.m
@@ -20,7 +20,6 @@
         NSString *slackMessage;
         if ([UserData userSlackMessage].length > 0) {
             slackMessage = [MailHandler parseMessage:[UserData userSlackMessage] forProject:project];
-            slackMessage = [slackMessage stringByAppendingFormat:@" - %@", project.appShortShareableURL];
         } else {
             slackMessage = [NSString stringWithFormat:@"%@ - %@ (%@) link - %@", project.name, project.version, project.build, project.appShortShareableURL];
         }

--- a/AppBox/ViewController/PreferencesViewController/SlackPreferencesViewController/SlackPreferencesViewController.xib
+++ b/AppBox/ViewController/PreferencesViewController/SlackPreferencesViewController/SlackPreferencesViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,7 +18,7 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="892" height="317"/>
+            <rect key="frame" x="0.0" y="0.0" width="892" height="330"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Mjn-bT-CIG">
@@ -57,7 +57,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UIS-te-x1g">
-                    <rect key="frame" x="13" y="278" width="204" height="19"/>
+                    <rect key="frame" x="13" y="291" width="204" height="19"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="200" id="Apo-90-Dsy"/>
                     </constraints>
@@ -68,7 +68,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TBN-E3-vOT">
-                    <rect key="frame" x="230" y="275" width="647" height="24"/>
+                    <rect key="frame" x="230" y="288" width="647" height="24"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Add Link Prefix Message" drawsBackground="YES" id="2Hv-ni-fmB">
                         <font key="font" metaFont="systemLight" size="16"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -76,14 +76,15 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dNt-JQ-OEn">
-                    <rect key="frame" x="228" y="205" width="651" height="65"/>
+                    <rect key="frame" x="228" y="205" width="651" height="78"/>
                     <textFieldCell key="cell" selectable="YES" sendsActionOnEndEditing="YES" id="jnf-oH-zV9">
                         <font key="font" metaFont="system" size="10"/>
                         <string key="title">Supported Keywords: The
 {PROJECT_NAME} - For Project Name
 {BUILD_VERSION} - For Build Version
 {BUILD_NUMBER} - For Build Number 
-{PROJECT_SCHEME} - For Project Scheme</string>
+{PROJECT_SCHEME} - For Project Scheme
+{DOWNLOAD_URL} - For Download URL</string>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>


### PR DESCRIPTION
Allow to specify DOWNLOAD_URL keyword in Webhooks for more flexible message formatting.

This allows to format messages as links by including DOWNLOAD_URL in the message, like this format for Slack:

<{DOWNLOAD_URL}|{PROJECT_NAME}-{BUILD_VERSION}.{BUILD_NUMBER}>

<img width="492" alt="create linked message" src="https://user-images.githubusercontent.com/43665/109794938-f849ae80-7c48-11eb-873e-988c0383fafb.png">

 If DOWNLOAD_URL keyword is not specified, link will be appended as before.

I've tested with Slack. I'm not familiar with the MS Team or Hangouts but I imagine they support link markup in a similar way.
